### PR TITLE
Add parentheses to sizeof int32_t to support more compilers

### DIFF
--- a/libHawk/GBAHawk/Core.h
+++ b/libHawk/GBAHawk/Core.h
@@ -354,13 +354,13 @@ namespace GBAHawk
 			int32_t* src = GBA.samples_L;
 			int32_t* dst = dest_L;
 
-			std::memcpy(dst, src, sizeof int32_t * GBA.num_samples_L * 2);
+			std::memcpy(dst, src, sizeof(int32_t) * GBA.num_samples_L * 2);
 			n_samp_L[0] = GBA.num_samples_L;
 
 			src = GBA.samples_R;
 			dst = dest_R;
 
-			std::memcpy(dst, src, sizeof int32_t * GBA.num_samples_R * 2);
+			std::memcpy(dst, src, sizeof(int32_t) * GBA.num_samples_R * 2);
 			n_samp_R[0] = GBA.num_samples_R;
 
 			uint32_t temp_int = GBA.snd_Master_Clock;

--- a/libHawk/GBAHawk/LinkCore.h
+++ b/libHawk/GBAHawk/LinkCore.h
@@ -455,13 +455,13 @@ namespace GBAHawk
 				int32_t* src = L.GBA.samples_L;
 				int32_t* dst = dest_L;
 
-				std::memcpy(dst, src, sizeof int32_t * L.GBA.num_samples_L * 2);
+				std::memcpy(dst, src, sizeof(int32_t) * L.GBA.num_samples_L * 2);
 				n_samp_L[0] = L.GBA.num_samples_L;
 
 				src = L.GBA.samples_R;
 				dst = dest_R;
 
-				std::memcpy(dst, src, sizeof int32_t * L.GBA.num_samples_R * 2);
+				std::memcpy(dst, src, sizeof(int32_t) * L.GBA.num_samples_R * 2);
 				n_samp_R[0] = L.GBA.num_samples_R;
 
 				uint32_t temp_int = L.GBA.snd_Master_Clock;
@@ -473,13 +473,13 @@ namespace GBAHawk
 				int32_t* src = R.GBA.samples_L;
 				int32_t* dst = dest_L;
 
-				std::memcpy(dst, src, sizeof int32_t * R.GBA.num_samples_L * 2);
+				std::memcpy(dst, src, sizeof(int32_t) * R.GBA.num_samples_L * 2);
 				n_samp_L[0] = R.GBA.num_samples_L;
 
 				src = R.GBA.samples_R;
 				dst = dest_R;
 
-				std::memcpy(dst, src, sizeof int32_t * R.GBA.num_samples_R * 2);
+				std::memcpy(dst, src, sizeof(int32_t) * R.GBA.num_samples_R * 2);
 				n_samp_R[0] = R.GBA.num_samples_R;
 
 				uint32_t temp_int = R.GBA.snd_Master_Clock;
@@ -491,13 +491,13 @@ namespace GBAHawk
 				int32_t* src = L.GBA.samples_L;
 				int32_t* dst = dest_L;
 
-				std::memcpy(dst, src, sizeof int32_t * L.GBA.num_samples_L * 2);
+				std::memcpy(dst, src, sizeof(int32_t) * L.GBA.num_samples_L * 2);
 				n_samp_L[0] = L.GBA.num_samples_L;
 
 				src = R.GBA.samples_R;
 				dst = dest_R;
 
-				std::memcpy(dst, src, sizeof int32_t * R.GBA.num_samples_R * 2);
+				std::memcpy(dst, src, sizeof(int32_t) * R.GBA.num_samples_R * 2);
 				n_samp_R[0] = R.GBA.num_samples_R;
 
 				uint32_t temp_int = (R.GBA.snd_Master_Clock > L.GBA.snd_Master_Clock) ? R.GBA.snd_Master_Clock : L.GBA.snd_Master_Clock;

--- a/libHawk/GBHawk/Core.h
+++ b/libHawk/GBHawk/Core.h
@@ -427,13 +427,13 @@ namespace GBHawk
 			int32_t* src = GB.samples_L;
 			int32_t* dst = dest_L;
 
-			std::memcpy(dst, src, sizeof int32_t * GB.num_samples_L * 2);
+			std::memcpy(dst, src, sizeof(int32_t) * GB.num_samples_L * 2);
 			n_samp_L[0] = GB.num_samples_L;
 
 			src = GB.samples_R;
 			dst = dest_R;
 
-			std::memcpy(dst, src, sizeof int32_t * GB.num_samples_R * 2);
+			std::memcpy(dst, src, sizeof(int32_t) * GB.num_samples_R * 2);
 			n_samp_R[0] = GB.num_samples_R;
 
 			uint32_t temp_int = GB.snd_Master_Clock;

--- a/libHawk/NESHawk/Core.h
+++ b/libHawk/NESHawk/Core.h
@@ -225,7 +225,7 @@ namespace NESHawk
 
 		void Load_Palette(uint8_t* ext_palette)
 		{
-			std::memcpy(NES.Compiled_Palette, ext_palette, sizeof int32_t * 512);
+			std::memcpy(NES.Compiled_Palette, ext_palette, sizeof(int32_t) * 512);
 		}
 
 		void Hard_Reset() 
@@ -365,7 +365,7 @@ namespace NESHawk
 			int32_t* src = NES.apu_Audio_Samples;
 			int32_t* dst = dest;
 
-			std::memcpy(dst, src, sizeof int32_t * NES.apu_Audio_Num_Samples * 2);
+			std::memcpy(dst, src, sizeof(int32_t) * NES.apu_Audio_Num_Samples * 2);
 			n_samp[0] = NES.apu_Audio_Num_Samples;
 
 			uint32_t temp_int = NES.apu_Audio_Sample_Clock;


### PR DESCRIPTION
I ran into a build error when trying to build this project with Clang and GCC. I found that `sizeof int32_t` is accepted only in MSVC. It gives this error in both Clang and GCC:

  `error: expected parentheses around type name in sizeof expression`

So it needs to be `sizeof(int32_t)` for these compilers. I think C++ standard actually requires the parentheses, but the code compiles with MSVC without them.

This PR just allows the project to build in a few more compilers by adding parentheses, and conform to C++ standard better as well. With this patch, it successfully builds on Clang and GCC. The change should be a no-op on MSVC too, and I verified that it still builds with MSVC as well.

I'm not sure if the GBHawk and NESHawk patches belong here, and I can't find where they live, so let me know if I should submit a patch upstream somewhere too.

GBAHawk is awesome. Thank you for this work!