### PR TITLE
Fix 8-bit PALRAM and BG writes

### DIFF
--- a/libHawk/GBAHawk/MemoryMap.cpp
+++ b/libHawk/GBAHawk/MemoryMap.cpp
@@ -524,8 +524,8 @@ namespace GBAHawk
 		else if (addr < 0x06000000)
 		{
 			// 8 bit writes to PALRAM stored as halfword
-			PALRAM[addr & 0x3FF] = value;
-			PALRAM[(addr + 1) & 0x3FF] = value;
+			PALRAM[addr & 0x3FE] = value;
+			PALRAM[(addr & 0x3FE) + 1] = value;
 
 			ppu_PALRAM_In_Use = false;
 		}
@@ -547,8 +547,8 @@ namespace GBAHawk
 						if ((addr & 0x17FFF) < 0x14000)
 						{
 							// 8 bit writes stored as halfword (needs more research)
-							VRAM[addr & 0x17FFF] = value;
-							VRAM[(addr + 1) & 0x17FFF] = value;
+							VRAM[addr & 0x17FFE] = value;
+							VRAM[(addr & 0x17FFE) + 1] = value;
 						}
 					}
 				}
@@ -559,8 +559,8 @@ namespace GBAHawk
 						if ((addr & 0x17FFF) < 0x14000)
 						{
 							// 8 bit writes stored as halfword (needs more research)
-							VRAM[addr & 0x17FFF] = value;
-							VRAM[(addr + 1) & 0x17FFF] = value;
+							VRAM[addr & 0x17FFE] = value;
+							VRAM[(addr & 0x17FFE) + 1] = value;
 						}
 					}
 				}
@@ -568,8 +568,8 @@ namespace GBAHawk
 			else
 			{
 				// 8 bit writes stored as halfword (needs more research)
-				VRAM[addr & 0xFFFF] = value;
-				VRAM[(addr + 1) & 0xFFFF] = value;
+				VRAM[addr & 0xFFFE] = value;
+				VRAM[(addr & 0xFFFE) + 1] = value;
 			}
 
 			ppu_VRAM_High_In_Use = false;


### PR DESCRIPTION
GBATEK [says](https://problemkaputt.de/gbatek-gba-unpredictable-things.htm):

> Writes to BG (6000000h-600FFFFh) (or 6000000h-6013FFFh in Bitmap mode) and to Palette (5000000h-50003FFh) are writing the new 8bit value to BOTH upper and lower 8bits of the addressed halfword, ie. "[addr AND NOT 1]=data*101h".


Our code for 8-bit writes to these regions:
```
PALRAM[addr & 0x3FF] = value;
PALRAM[(addr + 1) & 0x3FF] = value;
```
On an even addr, this is working. But on an odd addr, the bytes at addr and addr+1 are in different halfwords, so the write is misaligned.

On an even addr this writes: `[vv vv] [.. ..]`
On an odd addr this writes: `[.. vv] [vv ..]`

To fix this, we can clear the low bit to round addr down, keeping the write in the same halfword even when addr is odd:
```
PALRAM[addr & 0x3FE] = value;
PALRAM[(addr & 0x3FE) + 1] = value;
```
On an even addr this writes: `[vv vv] [.. ..]`
On an odd addr this writes: `[vv vv] [.. ..]`

I'm not sure how often real games actually try to do 8-bit writes to these regions, so I don't think it should improve compatibility very much, but I think this matches the hardware better. I noticed this when writing some tests. Thanks!